### PR TITLE
Add Skills section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 I am Dany, a Québécois living in the beautiful city of [Freiburg im Breisgau](https://en.wikipedia.org/wiki/Freiburg_im_Breisgau) in Germany. I speak French 🇨🇦, English and German 🇩🇪.
 
 For the past 12+ years, I have worked as a **Software / DevOps Engineer**. Beside work, I enjoy hiking, bouldering, playing board games, gardening, and anything related to technology.
+
+## Skills
+
+<!-- It's sad, but using a flexbox isn't possible here since GitHub heavily sanitize HTML/CSS in Markdown files... so the good ol' table is back and it cannot be styled :D -->
+
+| Web Development | Linux | DevOps | Ruby | Docker |
+|:---------------:|:-----:|:------:|:----:|:------:|
+| <img src="https://github.com/user-attachments/assets/61ee68d6-0b50-4bbe-ace7-c10d685c368a" height="80"> | <img src="https://github.com/user-attachments/assets/c8d61242-65fd-4371-828b-9f6763be63ce" height="80"> | <img src="https://github.com/user-attachments/assets/dfe0c15d-b383-4351-aa5e-73bd2a174546" height="80"> | <img src="https://github.com/user-attachments/assets/c3f0f259-8ac9-491b-989d-67f67b3d34d7" height="80"> | <img src="https://github.com/user-attachments/assets/04cf027a-1a63-41ce-9b3b-a95b9761850f" height="80"> |


### PR DESCRIPTION
 It's sad, but using a flexbox isn't possible here since GitHub heavily sanitize HTML/CSS in Markdown files... so the good ol' table is back and it cannot be styled :D